### PR TITLE
fix: Remove error thrown on nullable mismatch, prefer the second item…

### DIFF
--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -167,11 +167,7 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 	}
 	result.ExclusiveMax = s1.ExclusiveMax
 
-	if s1.Nullable != s2.Nullable {
-		return openapi3.Schema{}, errors.New("merging two schemas with different Nullable")
-
-	}
-	result.Nullable = s1.Nullable
+	result.Nullable = s2.Nullable // treating nullable as an overridable field
 
 	if s1.ReadOnly != s2.ReadOnly {
 		return openapi3.Schema{}, errors.New("merging two schemas with different ReadOnly")


### PR DESCRIPTION
…'s nullable field. Some openapi specs use `allof` to override nullable. There is some discourse about whether this is valid or not, but these schemas *do* pass openapi spec validation so this allows that design.